### PR TITLE
fixes to pom.xml and additional testing

### DIFF
--- a/debug.sh
+++ b/debug.sh
@@ -1,0 +1,43 @@
+#/bin/sh
+
+set -x
+set -e
+
+# Location of appengine-java-standard project.
+APPENGINE_JAVA_STANDARD="../appengine-java-standard"
+if [ ! -d "$APPENGINE_JAVA_STANDARD" ]; then
+  echo "Please modify APPENGINE_JAVA_STANDARD in this script to point to your local appengine-java-standard repository."
+  exit 1
+fi
+
+APPENGINE_STANDARD_DEMO="$(cd "$(dirname "$0")" && pwd)"
+APP_LOCATION="$APPENGINE_STANDARD_DEMO/target/appengine-staging"
+
+# Build the appengine-standard-demo project.
+cd $APPENGINE_STANDARD_DEMO
+mvn clean install -DskipTests
+rm -rf target/appengine-staging
+$APPENGINE_JAVA_STANDARD/sdk_assembly/target/appengine-java-sdk/bin/appcfg.sh stage target/appengine-spring-boot target/appengine-staging
+
+# Extract the runtime-deployment jars into a tmp directory.
+RUNTIME_DEPLOYMENT_ZIP=$(  find $APPENGINE_JAVA_STANDARD/runtime/deployment/target/ -name "runtime-deployment-*.zip" )
+RUNTIME_DEPLOYMENT="/tmp/runtime-deployment"
+mkdir -p $RUNTIME_DEPLOYMENT
+rm -rf ${RUNTIME_DEPLOYMENT:?}/*
+unzip $RUNTIME_DEPLOYMENT_ZIP -d $RUNTIME_DEPLOYMENT
+
+# To start API Server you run this from root of appengine-java-standard repository.
+# mvn exec:java -pl :appengine-apis-dev -Dexec.mainClass="com.google.appengine.tools.development.HttpApiServer"
+
+"$JAVA_HOME"/bin/java \
+ --add-opens java.base/java.lang=ALL-UNNAMED \
+ --add-opens java.base/java.nio.charset=ALL-UNNAMED \
+ --add-opens java.logging/java.util.logging=ALL-UNNAMED \
+ --add-opens java.base/java.util.concurrent=ALL-UNNAMED \
+ -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000 \
+ -showversion -XX:+PrintCommandLineFlags \
+ -Djava.class.path=$RUNTIME_DEPLOYMENT/runtime-main.jar \
+ -Dclasspath.runtimebase=$RUNTIME_DEPLOYMENT: \
+ com/google/apphosting/runtime/JavaRuntimeMainWithDefaults \
+ --fixed_application_path=$APP_LOCATION  \
+ $RUNTIME_DEPLOYMENT

--- a/pom.xml
+++ b/pom.xml
@@ -133,28 +133,6 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-tomcat</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-starter-websocket</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-jetty</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.eclipse.jetty.ee11.websocket</groupId>
-                    <artifactId>jetty-ee11-websocket-jakarta-client</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.eclipse.jetty.ee11.websocket</groupId>
-                    <artifactId>jetty-ee11-websocket-jakarta-server</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.eclipse.jetty.ee11.websocket</groupId>
-                    <artifactId>jetty-ee11-websocket-jetty-server</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -231,10 +209,11 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>
-
+        <finalName>appengine-spring-boot</finalName>
         <plugins>
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>

--- a/src/main/java/com/github/michaeltecourt/appengine/server/SampleSpringBootApplication.java
+++ b/src/main/java/com/github/michaeltecourt/appengine/server/SampleSpringBootApplication.java
@@ -17,20 +17,18 @@ package com.github.michaeltecourt.appengine.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.web.server.servlet.context.ServletComponentScan;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 
 /**
  * Spring Boot application entry point. Because it extends
- * {@link SpringBootServletInitializer} it should be detected without a web.xml
- * file (GAE team is fixing this).
+ * {@link SpringBootServletInitializer} it will be detected without a web.xml
+ * file.
  * 
  * @author michaeltecourt
  */
-@ServletComponentScan("com.github.michaeltecourt.appengine.server") // Needed to scan extra servlets in this package in this application.
 @SpringBootApplication
-public class SampleSpringBootApplication extends SpringBootServletInitializer {
-
+public class SampleSpringBootApplication extends SpringBootServletInitializer
+{
     public static void main(String[] args) {
         // This main method is not used by Google App Engine, which only needs
         // an empty @SpringBootApplication class from SpringBootServletInitializer.

--- a/src/main/webapp/WEB-INF/jsp/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/index.jsp
@@ -41,6 +41,8 @@
       <li><a href="/appengine_apis">/appengine_apis which shows an advanced selection of usage for AppEngine APIs.</a></li>
       <li><a href="/aliens">/aliens</a></li>
       <li><a href="/admin">/admin</a></li>
+      <li><a href="/stacktrace">Print Stacktrace</a></li>
+      <li><a href="/ee11Test">Test Servlet 6.1 API</a></li>
       <li><a href="/actuator/metrics">actuator/metrics</a></li>
       <li><a href="actuator/metrics/jvm.memory.max">actuator/metrics/jvm.memory.max</a></li>
       <li><a href="actuator/health">actuator/health</a></li>


### PR DESCRIPTION
- We do not need to include `spring-boot-starter-jetty` into pom.xml because we are building a war and do not want Jetty implementation jars to be inside the `WEB-INF/lib` directory.
- Include a script for testing with the Jars from runtime-deployment.
- Add endpoints at `/stacktrace` and `/ee11Test` for manual testing.